### PR TITLE
chore: fix fake comment and add example for github auth

### DIFF
--- a/hooks/available.lua
+++ b/hooks/available.lua
@@ -13,9 +13,12 @@ function PLUGIN:Available(ctx)
     -- Example 2: GitHub Releases API (for tools that use GitHub releases)
     -- local repo_url = "https://api.github.com/repos/<GITHUB_USER>/<GITHUB_REPO>/releases"
 
-    -- mise automatically handles GitHub authentication - no manual token setup needed
+    -- mise DOESN'T automatically handles GitHub authentication - manual token setup needed
     local resp, err = http.get({
         url = repo_url,
+        headers = {
+            ["Authorization"] = ("Bearer " .. (os.getenv("GITHUB_TOKEN") or os.getenv("MISE_GITHUB_TOKEN") or "")):match("^Bearer .+$"),
+        }
     })
 
     if err ~= nil then


### PR DESCRIPTION
The original comment isn't true, and since GitHub keeps restricting non-authenticated requests with rate limiting. So I think it worths an example of how to do that.

This PR attempts to address the "bug" report in https://github.com/jdx/mise/discussions/7779