### PR TITLE
docs(template): align metadata.lua with mise vfox metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Search and replace these placeholders throughout the project:
 - `<GITHUB_REPO>` → the upstream tool's GitHub repository name
 
 Files to update:
-- `metadata.lua` - Update name, version, description, author, license, homepage (and optional `depends` / `legacyFilenames` if needed)
+- `metadata.lua` - Update name, version, description, author, license, homepage (and optional `legacyFilenames` / commented `depends` if needed)
 - `hooks/*.lua` - Replace placeholders in all hook files
 - `mise-tasks/test` - Update test version and command
 - `README.md` - Update this file with your tool's information

--- a/README.md
+++ b/README.md
@@ -164,14 +164,6 @@ Enable debug output:
 MISE_DEBUG=1 mise install <TOOL>@latest
 ```
 
-## Install-time tool dependencies
-
-If install hooks run another mise-managed executable (for example `cmd.exec` calling `go` or `node`), list those tools in **`metadata.lua`** as `depends = { "go", ... }` using the same tool names as in `mise.toml`.
-
-When matching tools are configured, mise uses those entries to order current install jobs and to build the hook `PATH`. This is separate from `depends` on a `[tools]` line in `mise.toml`, which only makes one configured tool wait for another configured tool in the install graph.
-
-See [Tool plugin development — metadata.lua](https://mise.jdx.dev/tool-plugin-development.html#_2-metadata-lua).
-
 ## Files
 
 - `metadata.lua` – Plugin metadata and configuration

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Search and replace these placeholders throughout the project:
 - `<GITHUB_REPO>` → the upstream tool's GitHub repository name
 
 Files to update:
-- `metadata.lua` - Update name, version, description, author, license, homepage (and optional `legacyFilenames` / commented `depends` if needed)
+- `metadata.lua` - Update name, version, description, author, license, homepage, and optional metadata
 - `hooks/*.lua` - Replace placeholders in all hook files
 - `mise-tasks/test` - Update test version and command
 - `README.md` - Update this file with your tool's information
@@ -166,7 +166,9 @@ MISE_DEBUG=1 mise install <TOOL>@latest
 
 ## Install-time tool dependencies
 
-If install hooks run another mise-managed executable (for example `cmd.exec` calling `go` or `node`), list those tools in **`metadata.lua`** as `depends = { "go", ... }` using the **same tool names as in `mise.toml`**. mise installs them first and exposes them on `PATH` in the dependency environment used during your plugin’s install. This is separate from `depends` on a `[tools]` line in `mise.toml`, which only affects install order among tools already in your config.
+If install hooks run another mise-managed executable (for example `cmd.exec` calling `go` or `node`), list those tools in **`metadata.lua`** as `depends = { "go", ... }` using the same tool names as in `mise.toml`.
+
+When matching tools are configured, mise uses those entries to order current install jobs and to build the hook `PATH`. This is separate from `depends` on a `[tools]` line in `mise.toml`, which only affects install order for that config entry.
 
 See [Tool plugin development — metadata.lua](https://mise.jdx.dev/tool-plugin-development.html#_2-metadata-lua).
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ MISE_DEBUG=1 mise install <TOOL>@latest
 
 ## Install-time tool dependencies
 
-If install hooks run another mise-managed executable (for example `cmd.exec` calling `go` or `node`), list those tools in **`metadata.lua`** as `depends = { "go", ... }` using their **short names**. mise installs them first and exposes them on `PATH` in the dependency environment used during your plugin’s install. This is separate from `depends` on a `[tools]` line in `mise.toml`, which only affects install order among tools already in your config.
+If install hooks run another mise-managed executable (for example `cmd.exec` calling `go` or `node`), list those tools in **`metadata.lua`** as `depends = { "go", ... }` using the **same tool names as in `mise.toml`**. mise installs them first and exposes them on `PATH` in the dependency environment used during your plugin’s install. This is separate from `depends` on a `[tools]` line in `mise.toml`, which only affects install order among tools already in your config.
 
 See [Tool plugin development — metadata.lua](https://mise.jdx.dev/tool-plugin-development.html#_2-metadata-lua).
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Search and replace these placeholders throughout the project:
 - `<GITHUB_REPO>` → the upstream tool's GitHub repository name
 
 Files to update:
-- `metadata.lua` - Update name, description, author, updateUrl
+- `metadata.lua` - Update name, description, author, updateUrl (and optional `depends` if hooks need other mise tools on `PATH` during install)
 - `hooks/*.lua` - Replace placeholders in all hook files
 - `mise-tasks/test` - Update test version and command
 - `README.md` - Update this file with your tool's information
@@ -164,9 +164,15 @@ Enable debug output:
 MISE_DEBUG=1 mise install <TOOL>@latest
 ```
 
+## Install-time tool dependencies
+
+If install hooks run another mise-managed executable (for example `cmd.exec` calling `go` or `node`), list those tools in **`metadata.lua`** as `depends = { "go", ... }` using their **short names**. mise installs them first and exposes them on `PATH` in the dependency environment used during your plugin’s install. This is separate from `depends` on a `[tools]` line in `mise.toml`, which only affects install order among tools already in your config.
+
+See [Tool plugin development — metadata.lua](https://mise.jdx.dev/tool-plugin-development.html#_2-metadata-lua).
+
 ## Files
 
-- `metadata.lua` – Plugin metadata and configuration
+- `metadata.lua` – Plugin metadata and configuration (optional `depends` for hook-time `PATH`)
 - `hooks/available.lua` – Returns available versions from upstream
 - `hooks/pre_install.lua` – Returns artifact URL for a given version
 - `hooks/post_install.lua` – Post-installation setup (permissions, moving files)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Search and replace these placeholders throughout the project:
 - `<GITHUB_REPO>` → the upstream tool's GitHub repository name
 
 Files to update:
-- `metadata.lua` - Update name, description, author, updateUrl (and optional `depends` if hooks need other mise tools on `PATH` during install)
+- `metadata.lua` - Update name, version, description, author, license, homepage (and optional `depends` / `legacyFilenames` if needed)
 - `hooks/*.lua` - Replace placeholders in all hook files
 - `mise-tasks/test` - Update test version and command
 - `README.md` - Update this file with your tool's information

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ See [Tool plugin development — metadata.lua](https://mise.jdx.dev/tool-plugin-
 
 ## Files
 
-- `metadata.lua` – Plugin metadata and configuration (optional `depends` for hook-time `PATH`)
+- `metadata.lua` – Plugin metadata and configuration
 - `hooks/available.lua` – Returns available versions from upstream
 - `hooks/pre_install.lua` – Returns artifact URL for a given version
 - `hooks/post_install.lua` – Post-installation setup (permissions, moving files)

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ MISE_DEBUG=1 mise install <TOOL>@latest
 
 If install hooks run another mise-managed executable (for example `cmd.exec` calling `go` or `node`), list those tools in **`metadata.lua`** as `depends = { "go", ... }` using the same tool names as in `mise.toml`.
 
-When matching tools are configured, mise uses those entries to order current install jobs and to build the hook `PATH`. This is separate from `depends` on a `[tools]` line in `mise.toml`, which only affects install order for that config entry.
+When matching tools are configured, mise uses those entries to order current install jobs and to build the hook `PATH`. This is separate from `depends` on a `[tools]` line in `mise.toml`, which only makes one configured tool wait for another configured tool in the install graph.
 
 See [Tool plugin development — metadata.lua](https://mise.jdx.dev/tool-plugin-development.html#_2-metadata-lua).
 

--- a/metadata.lua
+++ b/metadata.lua
@@ -21,7 +21,8 @@ PLUGIN = { -- luacheck: ignore
     -- Optional: Project or plugin home page
     homepage = "https://github.com/<GITHUB_USER>/mise-<TOOL>",
 
-    -- depends = { "node" },
+    -- Optional: mise tools needed on PATH during install hooks (names as in mise.toml)
+    depends = {},
 
     -- Optional: Legacy version files this plugin can parse
     -- legacyFilenames = {

--- a/metadata.lua
+++ b/metadata.lua
@@ -27,6 +27,6 @@ PLUGIN = { -- luacheck: ignore
     --     ".<TOOL>rc"
     -- },
 
-    -- Optional: mise tools on PATH during install hooks (names as in mise.toml)
+    -- Optional: configured mise tools to add to install-hook PATH
     -- depends = { "node" },
 }

--- a/metadata.lua
+++ b/metadata.lua
@@ -9,16 +9,16 @@ PLUGIN = { -- luacheck: ignore
     -- Required: Plugin metadata version
     version = "1.0.0",
 
-    -- Required: Brief description of the tool
+    -- Optional: Plugin description
     description = "A mise tool plugin for <TOOL>",
 
-    -- Required: Plugin author/maintainer
+    -- Optional: Plugin author
     author = "<GITHUB_USER>",
 
-    -- Optional: SPDX license id or name
+    -- Optional: License name
     license = "MIT",
 
-    -- Optional: Project or plugin home page
+    -- Optional: Plugin homepage
     homepage = "https://github.com/<GITHUB_USER>/mise-<TOOL>",
 
     -- Optional: Legacy version files this plugin can parse

--- a/metadata.lua
+++ b/metadata.lua
@@ -23,7 +23,8 @@ PLUGIN = { -- luacheck: ignore
 
     -- Optional: Other mise-managed tools that must install first and be on PATH
     -- while running install hooks (Lua `cmd`, etc.). Use the same tool names as in
-    -- mise.toml ("node", "go", …). This feeds mise's dependency environment; it is not the same as
+    -- mise.toml ("node", "go", …). mise uses these for install scheduling and hook-time `PATH`;
+    -- they are not the same as
     -- `depends` on a `[tools]` entry in mise.toml (that only orders installs among
     -- tools you already list in config).
     -- See https://mise.jdx.dev/tool-plugin-development.html#_2-metadata-lua

--- a/metadata.lua
+++ b/metadata.lua
@@ -21,6 +21,14 @@ PLUGIN = { -- luacheck: ignore
     -- Optional: Minimum mise runtime version required
     minRuntimeVersion = "0.2.0",
 
+    -- Optional: Other mise-managed tools that must install first and be on PATH
+    -- while running install hooks (Lua `cmd`, etc.). Use mise short names ("node",
+    -- "go", …). This feeds mise's dependency environment; it is not the same as
+    -- `depends` on a `[tools]` entry in mise.toml (that only orders installs among
+    -- tools you already list in config).
+    -- See https://mise.jdx.dev/tool-plugin-development.html#_2-metadata-lua
+    -- depends = { "node" },
+
     -- Optional: Legacy version files this plugin can parse
     -- legacyFilenames = {
     --     ".<TOOL>-version",

--- a/metadata.lua
+++ b/metadata.lua
@@ -21,12 +21,12 @@ PLUGIN = { -- luacheck: ignore
     -- Optional: Project or plugin home page
     homepage = "https://github.com/<GITHUB_USER>/mise-<TOOL>",
 
-    -- Optional: mise tools needed on PATH during install hooks (names as in mise.toml)
-    depends = {},
-
     -- Optional: Legacy version files this plugin can parse
     -- legacyFilenames = {
     --     ".<TOOL>-version",
     --     ".<TOOL>rc"
-    -- }
+    -- },
+
+    -- Optional: mise tools on PATH during install hooks (names as in mise.toml)
+    -- depends = { "node" },
 }

--- a/metadata.lua
+++ b/metadata.lua
@@ -3,10 +3,10 @@
 -- Documentation: https://mise.jdx.dev/tool-plugin-development.html#metadata-lua
 
 PLUGIN = { -- luacheck: ignore
-    -- Required: Tool name (lowercase, no spaces)
+    -- Required: Plugin metadata name
     name = "<TOOL>",
 
-    -- Required: Plugin version (not the tool version)
+    -- Required: Plugin metadata version
     version = "1.0.0",
 
     -- Required: Brief description of the tool

--- a/metadata.lua
+++ b/metadata.lua
@@ -15,19 +15,12 @@ PLUGIN = { -- luacheck: ignore
     -- Required: Plugin author/maintainer
     author = "<GITHUB_USER>",
 
-    -- Optional: Repository URL for plugin updates
-    updateUrl = "https://github.com/<GITHUB_USER>/mise-<TOOL>",
+    -- Optional: SPDX license id or name
+    license = "MIT",
 
-    -- Optional: Minimum mise runtime version required
-    minRuntimeVersion = "0.2.0",
+    -- Optional: Project or plugin home page
+    homepage = "https://github.com/<GITHUB_USER>/mise-<TOOL>",
 
-    -- Optional: Other mise-managed tools that must install first and be on PATH
-    -- while running install hooks (Lua `cmd`, etc.). Use the same tool names as in
-    -- mise.toml ("node", "go", …). mise uses these for install scheduling and hook-time `PATH`;
-    -- they are not the same as
-    -- `depends` on a `[tools]` entry in mise.toml (that only orders installs among
-    -- tools you already list in config).
-    -- See https://mise.jdx.dev/tool-plugin-development.html#_2-metadata-lua
     -- depends = { "node" },
 
     -- Optional: Legacy version files this plugin can parse

--- a/metadata.lua
+++ b/metadata.lua
@@ -22,8 +22,8 @@ PLUGIN = { -- luacheck: ignore
     minRuntimeVersion = "0.2.0",
 
     -- Optional: Other mise-managed tools that must install first and be on PATH
-    -- while running install hooks (Lua `cmd`, etc.). Use mise short names ("node",
-    -- "go", …). This feeds mise's dependency environment; it is not the same as
+    -- while running install hooks (Lua `cmd`, etc.). Use the same tool names as in
+    -- mise.toml ("node", "go", …). This feeds mise's dependency environment; it is not the same as
     -- `depends` on a `[tools]` entry in mise.toml (that only orders installs among
     -- tools you already list in config).
     -- See https://mise.jdx.dev/tool-plugin-development.html#_2-metadata-lua

--- a/types/mise-plugin.lua
+++ b/types/mise-plugin.lua
@@ -128,7 +128,7 @@ ARCH_TYPE = ""
 ---@field license? string SPDX id or license name (e.g. `MIT`)
 ---@field homepage? string Project or repository URL
 ---@field legacyFilenames? string[] Basenames of version files `ParseLegacyFile` can read (camelCase key: `legacyFilenames`)
----@field depends? string[] Other mise tools that must install first and appear on PATH during install hooks
+---@field depends? string[] Configured mise tools whose bin paths should be available during install hooks
 ---@field Available? fun(self: Plugin, ctx: AvailableCtx): AvailableVersion[]
 ---@field PreInstall? fun(self: Plugin, ctx: PreInstallCtx): PreInstallResult
 ---@field PostInstall? fun(self: Plugin, ctx: PostInstallCtx)

--- a/types/mise-plugin.lua
+++ b/types/mise-plugin.lua
@@ -121,7 +121,13 @@ ARCH_TYPE = ""
 
 ---@class Plugin
 ---@field name string Plugin name
----@field depends? string[] From metadata.lua: other mise tools (names as in mise.toml) required on PATH during install hooks
+---@field version string Plugin manifest version
+---@field description? string
+---@field author? string
+---@field license? string
+---@field homepage? string
+---@field legacyFilenames? string[]
+---@field depends? string[] Other mise tools (names as in mise.toml) required on PATH during install hooks
 ---@field Available? fun(self: Plugin, ctx: AvailableCtx): AvailableVersion[]
 ---@field PreInstall? fun(self: Plugin, ctx: PreInstallCtx): PreInstallResult
 ---@field PostInstall? fun(self: Plugin, ctx: PostInstallCtx)

--- a/types/mise-plugin.lua
+++ b/types/mise-plugin.lua
@@ -121,7 +121,7 @@ ARCH_TYPE = ""
 
 ---@class Plugin
 ---@field name string Plugin name
----@field depends? string[] From metadata.lua: other mise tool short names required on PATH during install hooks
+---@field depends? string[] From metadata.lua: other mise tools (names as in mise.toml) required on PATH during install hooks
 ---@field Available? fun(self: Plugin, ctx: AvailableCtx): AvailableVersion[]
 ---@field PreInstall? fun(self: Plugin, ctx: PreInstallCtx): PreInstallResult
 ---@field PostInstall? fun(self: Plugin, ctx: PostInstallCtx)

--- a/types/mise-plugin.lua
+++ b/types/mise-plugin.lua
@@ -121,8 +121,8 @@ ARCH_TYPE = ""
 
 ---@class Plugin
 --- Keys for `metadata.lua` (mise loads these via vfox `Metadata`). Hook methods are separate optional entries on the same table.
----@field name string Tool id this plugin manages (lowercase, e.g. `nodejs`)
----@field version string Plugin/package version string — not the installed tool SDK version
+---@field name string Plugin metadata name
+---@field version string Plugin metadata version
 ---@field description? string Human-readable description of the plugin or tool
 ---@field author? string Maintainer or author name
 ---@field license? string SPDX id or license name (e.g. `MIT`)

--- a/types/mise-plugin.lua
+++ b/types/mise-plugin.lua
@@ -120,14 +120,15 @@ ARCH_TYPE = ""
 ---@field env_vars EnvKey[] Environment variables to set
 
 ---@class Plugin
----@field name string Plugin name
----@field version string Plugin manifest version
----@field description? string
----@field author? string
----@field license? string
----@field homepage? string
----@field legacyFilenames? string[]
----@field depends? string[] Other mise tools (names as in mise.toml) required on PATH during install hooks
+--- Keys for `metadata.lua` (mise loads these via vfox `Metadata`). Hook methods are separate optional entries on the same table.
+---@field name string Tool id this plugin manages (lowercase, e.g. `nodejs`)
+---@field version string Plugin/package version string — not the installed tool SDK version
+---@field description? string Human-readable description of the plugin or tool
+---@field author? string Maintainer or author name
+---@field license? string SPDX id or license name (e.g. `MIT`)
+---@field homepage? string Project or repository URL
+---@field legacyFilenames? string[] Basenames of version files `ParseLegacyFile` can read (camelCase key: `legacyFilenames`)
+---@field depends? string[] Other mise tools that must install first and appear on PATH during install hooks
 ---@field Available? fun(self: Plugin, ctx: AvailableCtx): AvailableVersion[]
 ---@field PreInstall? fun(self: Plugin, ctx: PreInstallCtx): PreInstallResult
 ---@field PostInstall? fun(self: Plugin, ctx: PostInstallCtx)

--- a/types/mise-plugin.lua
+++ b/types/mise-plugin.lua
@@ -9,6 +9,7 @@
 ---@class Runtime
 ---@field osType string Operating system type (e.g. "linux", "darwin", "windows")
 ---@field archType string Architecture type (e.g. "amd64", "arm64")
+---@field envType? string Runtime environment type
 ---@field version string Runtime version
 ---@field pluginDirPath string Path to the plugin directory
 RUNTIME = {}
@@ -32,7 +33,8 @@ ARCH_TYPE = ""
 ---@field checksum? string Checksum for detecting changes in rolling releases
 
 ---@class AvailableCtx
----@field args string[] Command-line arguments
+---@field args string[]
+---@field version? string
 
 ---@class PreInstallResult
 ---@field version string Version string
@@ -54,7 +56,7 @@ ARCH_TYPE = ""
 ---@field slsa_min_level? integer Minimum SLSA level
 
 ---@class PreInstallCtx
----@field args string[] Command-line arguments
+---@field args string[]
 ---@field version string Requested version
 
 ---@class PostInstallCtx
@@ -63,9 +65,9 @@ ARCH_TYPE = ""
 ---@field sdkInfo table<string, SdkInfo> SDK info for installed versions
 
 ---@class SdkInfo
+---@field name string SDK name
 ---@field path string Installation path
 ---@field version string Installed version
----@field note? string Optional note
 
 ---@class EnvKey
 ---@field key string Environment variable name
@@ -89,17 +91,21 @@ ARCH_TYPE = ""
 
 ---@class MiseEnvCtx
 ---@field options table Plugin options from mise.toml
+---@field config_root? string Configuration root path
 
 ---@class MiseEnvResult
 ---@field env? EnvKey[] Environment variables to set
 ---@field cacheable? boolean Whether the result can be cached (default false)
 ---@field watch_files? string[] Files to watch for cache invalidation
+---@field redact? boolean Whether env var values should be redacted
 
 ---@class MisePathCtx
 ---@field options table Plugin options from mise.toml
+---@field config_root? string Configuration root path
 
 ---@class BackendListVersionsCtx
 ---@field tool string Tool name
+---@field options table Plugin options from mise.toml
 
 ---@class BackendListVersionsResult
 ---@field versions string[] List of available versions
@@ -108,6 +114,8 @@ ARCH_TYPE = ""
 ---@field tool string Tool name
 ---@field version string Version to install
 ---@field install_path string Path where the tool should be installed
+---@field download_path string Download cache path
+---@field options table Plugin options from mise.toml
 
 ---@class BackendInstallResult
 
@@ -115,6 +123,7 @@ ARCH_TYPE = ""
 ---@field tool string Tool name
 ---@field version string Installed version
 ---@field install_path string Installation path
+---@field options table Plugin options from mise.toml
 
 ---@class BackendExecEnvResult
 ---@field env_vars EnvKey[] Environment variables to set
@@ -123,11 +132,11 @@ ARCH_TYPE = ""
 --- Keys for `metadata.lua` (mise loads these via vfox `Metadata`). Hook methods are separate optional entries on the same table.
 ---@field name string Plugin metadata name
 ---@field version string Plugin metadata version
----@field description? string Human-readable description of the plugin or tool
----@field author? string Maintainer or author name
----@field license? string SPDX id or license name (e.g. `MIT`)
----@field homepage? string Project or repository URL
----@field legacyFilenames? string[] Basenames of version files `ParseLegacyFile` can read (camelCase key: `legacyFilenames`)
+---@field description? string Plugin description
+---@field author? string Plugin author
+---@field license? string License name
+---@field homepage? string Plugin homepage
+---@field legacyFilenames? string[] Legacy version filenames
 ---@field depends? string[] Configured mise tools whose bin paths should be available during install hooks
 ---@field Available? fun(self: Plugin, ctx: AvailableCtx): AvailableVersion[]
 ---@field PreInstall? fun(self: Plugin, ctx: PreInstallCtx): PreInstallResult

--- a/types/mise-plugin.lua
+++ b/types/mise-plugin.lua
@@ -121,6 +121,7 @@ ARCH_TYPE = ""
 
 ---@class Plugin
 ---@field name string Plugin name
+---@field depends? string[] From metadata.lua: other mise tool short names required on PATH during install hooks
 ---@field Available? fun(self: Plugin, ctx: AvailableCtx): AvailableVersion[]
 ---@field PreInstall? fun(self: Plugin, ctx: PreInstallCtx): PreInstallResult
 ---@field PostInstall? fun(self: Plugin, ctx: PostInstallCtx)


### PR DESCRIPTION
## Summary

- Align `metadata.lua` with the required and optional fields mise parses from `PLUGIN`.
- Keep dependency details in the mise docs instead of duplicating them in the template README.
- Update LuaCATS annotations to match the vfox Rust structs and generated hook tables more closely, without implying extra validation or behavior.

## Notes

`name` and `version` are required metadata strings in `crates/vfox/src/metadata.rs`; mise does not validate lowercase formatting for `name`, and `version` is plugin metadata rather than an installed tool version.

`description`, `author`, `license`, and `homepage` are optional metadata strings. The template now describes `homepage` as the plugin homepage and `license` as a license name.

## Verification

- `git diff --check`

## Project review — 2026-09-05

Status: **In progress**. [This PR](https://github.com/jdx/mise-tool-plugin-template/pull/8) is open; implementation exists and awaits completion/review. Remaining acceptance: compare `metadata.lua` and LuaCATS definitions with current mise metadata/hook structs; required `name`/`version` versus optional description/author/license/homepage must match deserialization, and annotations must not promise validation the runtime lacks. Check config-root/options/download-path/envType/redact fields at their actual hooks. Keep dependency semantics linked to canonical mise docs. No checks were rerun in this project audit.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*