### PR TITLE
docs(template): remove registry publishing step

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,6 @@ Refer to the mise docs for detailed information:
 2. Create a GitHub repository for your plugin
 3. Push your code
 4. (Optional) Request to transfer to [mise-plugins](https://github.com/mise-plugins) organization
-5. Add to the [mise registry](https://github.com/jdx/mise/blob/main/registry.toml) via PR
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,6 @@ Refer to the mise docs for detailed information:
 1. Ensure all tests pass: `mise run ci`
 2. Create a GitHub repository for your plugin
 3. Push your code
-4. (Optional) Request to transfer to [mise-plugins](https://github.com/mise-plugins) organization
 
 ## License
 


### PR DESCRIPTION
## Summary

- Remove the template README checklist item that tells plugin authors to add their plugin to the mise registry.
- Remove the publishing checklist item suggesting transfer to the mise-plugins organization.
- Leave registry and organization acceptance guidance to the main mise docs.

## Context

jdx recently clarified registry backend acceptance policy in mise PR #9543. The template should not encourage a registry PR or organization transfer as normal plugin publishing steps.

## Verification

- `git diff --check`

## Project review — 2026-09-05

Status: **In progress**. [This PR](https://github.com/jdx/mise-tool-plugin-template/pull/9) is open; implementation exists and awaits completion/review. Remaining acceptance: the publishing checklist should explain creating/pushing the plugin repository and running CI, with a canonical mise documentation link. It must not imply registry admission or organization transfer is a standard publishing step. Review the existing README diff and whitespace check; no source behavior change or new registry entry is required. No checks were rerun in this project audit.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*